### PR TITLE
Add quick expense dialog with floating action button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,3 +91,67 @@ h1 {
   font-weight: bold;
   text-align: right;
 }
+
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.quick-add-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-add-form {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quick-add-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 0.25rem;
+}
+
+.quick-add-form .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.quick-add-form button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.quick-add-form button[type="submit"] {
+  background: #4f46e5;
+  color: #fff;
+}
+
+.quick-add-form button[type="button"] {
+  background: #ccc;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Layout from './components/Layout';
 
 const currency = new Intl.NumberFormat('en-LK', {
   style: 'currency',
@@ -105,8 +106,12 @@ export default function App() {
     setExpenses(expenses.filter(ex => ex.id !== id));
   }
 
+  function quickAddExpense(exp) {
+    setExpenses([...expenses, { id: Date.now(), ...exp }]);
+  }
   return (
-    <div className="container">
+    <Layout onAddExpense={quickAddExpense}>
+      <div className="container">
       <h1>Debt Manager</h1>
 
       <section className="section">
@@ -211,5 +216,6 @@ export default function App() {
         <p className="summary">Remaining Balance: {currency.format(remaining)}</p>
       </section>
     </div>
+    </Layout>
   );
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import QuickAddExpense from './QuickAddExpense';
+
+export default function Layout({ children, onAddExpense }) {
+  const [open, setOpen] = useState(false);
+
+  function handleSave(expense) {
+    onAddExpense(expense);
+    setOpen(false);
+  }
+
+  return (
+    <>
+      {children}
+      <button className="fab" onClick={() => setOpen(true)}>
+        +
+      </button>
+      {open && (
+        <QuickAddExpense
+          onSave={handleSave}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/QuickAddExpense.jsx
+++ b/src/components/QuickAddExpense.jsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+
+const categories = ['Food', 'Transport', 'Utilities', 'Other'];
+
+export default function QuickAddExpense({ onSave, onClose }) {
+  const [desc, setDesc] = useState('');
+  const [amount, setAmount] = useState('');
+  const [category, setCategory] = useState(
+    () => localStorage.getItem('lastExpenseCategory') || categories[0]
+  );
+
+  useEffect(() => {
+    localStorage.setItem('lastExpenseCategory', category);
+  }, [category]);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (!desc || !amount) return;
+    onSave({ desc, amount: Number(amount), category });
+    setDesc('');
+    setAmount('');
+  }
+
+  return (
+    <div className="quick-add-overlay">
+      <form className="quick-add-form" onSubmit={handleSubmit}>
+        <h2>Quick Add Expense</h2>
+        <label>
+          Description
+          <input value={desc} onChange={e => setDesc(e.target.value)} />
+        </label>
+        <label>
+          Amount (LKR)
+          <input
+            type="number"
+            value={amount}
+            onChange={e => setAmount(e.target.value)}
+          />
+        </label>
+        <label>
+          Category
+          <select value={category} onChange={e => setCategory(e.target.value)}>
+            {categories.map(cat => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit">Add</button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add QuickAddExpense component with description, amount, and category fields that persist last category to local storage.
- Introduce Layout with a floating action button to open the quick-add dialog and pass expense data back to the app.
- Wire Layout into App and style the dialog and FAB for quick expense entry.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a62a9c3c64833280a083d9221fd2c6