### PR TITLE
feat: add accessible charts with recharts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^2.10.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/components/charts/CashflowChart.jsx
+++ b/src/components/charts/CashflowChart.jsx
@@ -1,0 +1,48 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+
+const srOnly = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  width: '1px',
+};
+
+export default function CashflowChart({ data = [] }) {
+  return (
+    <figure aria-label="Cashflow chart">
+      <div aria-hidden="true">
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="value" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <table style={srOnly} aria-label="Cashflow data table">
+        <caption>Cashflow</caption>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.date}>
+              <td>{item.date}</td>
+              <td>{item.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}
+

--- a/src/components/charts/DebtProgressChart.jsx
+++ b/src/components/charts/DebtProgressChart.jsx
@@ -1,0 +1,48 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+
+const srOnly = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  width: '1px',
+};
+
+export default function DebtProgressChart({ data = [] }) {
+  return (
+    <figure aria-label="Debt progress chart">
+      <div aria-hidden="true">
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="period" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="balance" fill="#82ca9d" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <table style={srOnly} aria-label="Debt progress data table">
+        <caption>Debt Progress</caption>
+        <thead>
+          <tr>
+            <th>Period</th>
+            <th>Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.period}>
+              <td>{item.period}</td>
+              <td>{item.balance}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}
+

--- a/src/components/charts/SpendByCategoryChart.jsx
+++ b/src/components/charts/SpendByCategoryChart.jsx
@@ -1,0 +1,45 @@
+import { ResponsiveContainer, PieChart, Pie, Tooltip } from 'recharts';
+
+const srOnly = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  width: '1px',
+};
+
+export default function SpendByCategoryChart({ data = [] }) {
+  return (
+    <figure aria-label="Spend by category chart">
+      <div aria-hidden="true">
+        <ResponsiveContainer width="100%" height={300}>
+          <PieChart>
+            <Pie data={data} dataKey="value" nameKey="category" />
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <table style={srOnly} aria-label="Spend by category data table">
+        <caption>Spend by Category</caption>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item) => (
+            <tr key={item.category}>
+              <td>{item.category}</td>
+              <td>{item.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Recharts dependency
- add SpendByCategoryChart, CashflowChart, and DebtProgressChart components with aria labels and hidden data tables

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a62a9bd3a08332b533e47b4d6dac9b