### PR TITLE
feat: add theme tokens and switcher

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,52 +1,52 @@
 body {
   margin: 0;
-  font-family: system-ui, sans-serif;
-  background: linear-gradient(135deg, #74ebd5 0%, #acb6e5 100%);
+  font-family: var(--font-ui);
+  background: var(--color-bg);
   min-height: 100vh;
-  color: #333;
+  color: var(--color-fg);
 }
 
 .container {
   max-width: 800px;
   margin: 0 auto;
-  padding: 2rem;
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 12px;
+  padding: var(--space-6);
+  background: var(--color-muted);
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
 
 h1 {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: var(--space-6);
 }
 
 .section {
-  margin-bottom: 2rem;
-  background: #fff;
-  padding: 1rem;
-  border-radius: 8px;
+  margin-bottom: var(--space-6);
+  background: var(--color-bg);
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
 .form {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
 }
 
 .form input {
   flex: 1;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: var(--space-2);
+  border: 1px solid var(--color-muted);
+  border-radius: var(--radius-sm);
 }
 
 .form button {
-  padding: 0.5rem 1rem;
+  padding: var(--space-2) var(--space-4);
   border: none;
-  background: #4f46e5;
-  color: #fff;
-  border-radius: 4px;
+  background: var(--color-secondary);
+  color: var(--color-text-on-brand);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
@@ -60,31 +60,41 @@ h1 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem;
-  background: #f9f9f9;
-  border-radius: 4px;
-  margin-bottom: 0.5rem;
+  padding: var(--space-2);
+  background: var(--color-muted);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-2);
 }
 
 .list-item button {
-  margin-left: 0.5rem; /* match main branch spacing */
+  margin-left: var(--space-2); /* match main branch spacing */
   border: none;
-  color: #fff;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  color: var(--color-text-on-brand);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
 .list-item button.edit {
-  background: #10b981;
+  background: var(--color-success);
 }
 
 .list-item button.pay {
-  background: #3b82f6;
+  background: var(--color-primary);
 }
 
 .list-item button.remove {
-  background: #ef4444;
+  background: var(--color-danger);
+}
+
+.theme-toggle {
+  background: var(--color-primary);
+  color: var(--color-text-on-brand);
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  margin-bottom: var(--space-4);
 }
 
 .summary {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import ThemeSwitcher from './ThemeSwitcher';
 
 const currency = new Intl.NumberFormat('en-LK', {
   style: 'currency',
@@ -107,6 +108,7 @@ export default function App() {
 
   return (
     <div className="container">
+      <ThemeSwitcher />
       <h1>Debt Manager</h1>
 
       <section className="section">

--- a/src/ThemeSwitcher.jsx
+++ b/src/ThemeSwitcher.jsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+const themes = ['theme-light', 'theme-dark', 'theme-midnight'];
+
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = useState('theme-light');
+
+  useEffect(() => {
+    document.documentElement.classList.add(theme);
+    return () => {
+      document.documentElement.classList.remove(theme);
+    };
+  }, [theme]);
+
+  function cycleTheme() {
+    const next = themes[(themes.indexOf(theme) + 1) % themes.length];
+    setTheme(next);
+  }
+
+  return (
+    <button className="theme-toggle" onClick={cycleTheme}>
+      Theme: {theme.replace('theme-', '')}
+    </button>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './theme/tokens.css';
 import './App.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -1,0 +1,42 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root,
+.theme-light {
+  --color-bg: #FFFFFF;
+  --color-fg: #0B1220;
+  --color-primary: #2563EB;
+  --color-secondary: #7C3AED;
+  --color-success: #16A34A;
+  --color-warning: #F59E0B;
+  --color-danger: #DC2626;
+  --color-muted: #F3F4F6;
+  --color-text-on-brand: #FFFFFF;
+
+  --font-ui: 'Inter', system-ui, sans-serif;
+  --font-size-base: 16px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 40px;
+  --space-8: 64px;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+}
+
+.theme-dark {
+  --color-bg: #111827;
+  --color-fg: #F3F4F6;
+  --color-muted: #374151;
+}
+
+.theme-midnight {
+  --color-bg: #0B1220;
+  --color-fg: #FFFFFF;
+  --color-muted: #111827;
+}


### PR DESCRIPTION
## Summary
- add CSS design tokens and theme variants (light, dark, midnight)
- refactor styles to consume color, spacing, and font variables
- introduce a ThemeSwitcher component to toggle root theme classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a62a99975083328b48ca48452f5f1b