### PR TITLE
feat: add responsive layout component

### DIFF
--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -1,0 +1,57 @@
+.app-layout {
+  display: grid;
+  grid-template-areas:
+    "header header"
+    "sidebar content";
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr;
+  height: 100vh;
+}
+
+.app-header {
+  grid-area: header;
+  background: #f8f9fa;
+  padding: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.app-sidebar {
+  grid-area: sidebar;
+  background: #f1f5f9;
+  padding: 1rem;
+  border-right: 1px solid #e5e7eb;
+}
+
+.app-content {
+  grid-area: content;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.app-bottom-nav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .app-layout {
+    grid-template-areas:
+      "header"
+      "content"
+      "nav";
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+  }
+
+  .app-sidebar {
+    display: none;
+  }
+
+  .app-bottom-nav {
+    grid-area: nav;
+    display: flex;
+    justify-content: space-around;
+    background: #fff;
+    border-top: 1px solid #e5e7eb;
+    padding: 0.5rem 0;
+  }
+}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './Layout.css';
+
+export default function Layout({ children }) {
+  return (
+    <div className="app-layout">
+      <header className="app-header">Debt App</header>
+      <aside className="app-sidebar">
+        <nav>
+          <ul>
+            <li><a href="#">Overview</a></li>
+            <li><a href="#">Debts</a></li>
+            <li><a href="#">Income</a></li>
+            <li><a href="#">Expenses</a></li>
+          </ul>
+        </nav>
+      </aside>
+      <main className="app-content">{children}</main>
+      <nav className="app-bottom-nav">
+        <a href="#">Overview</a>
+        <a href="#">Debts</a>
+        <a href="#">Income</a>
+        <a href="#">Expenses</a>
+      </nav>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './App.css';
+import Layout from './components/Layout';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <Layout>
+      <App />
+    </Layout>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add Layout component with header, sidebar, content area, and mobile bottom navigation
- wire Layout into main entry point

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a62a996f88833287eb224cb15d6f94